### PR TITLE
Align collapsible sidebar items

### DIFF
--- a/src/components/app-sidebar/nav-team.vue
+++ b/src/components/app-sidebar/nav-team.vue
@@ -42,7 +42,7 @@ function isActive(menu: NavItem): boolean {
     <UiSidebarMenu>
       <template v-for="menu in group.items" :key="menu.title">
         <UiSidebarMenuItem v-if="!menu.items">
-          <UiSidebarMenuButton as-child :is-active="isActive(menu)">
+          <UiSidebarMenuButton as-child :is-active="isActive(menu)" :tooltip="menu.title">
             <router-link :to="menu.url">
               <component :is="menu.icon" />
               <span>{{ menu.title }}</span>

--- a/src/components/app-sidebar/nav-team.vue
+++ b/src/components/app-sidebar/nav-team.vue
@@ -85,9 +85,10 @@ function isActive(menu: NavItem): boolean {
           <!-- sidebar collapsed -->
           <UiDropdownMenu v-else>
             <UiDropdownMenuTrigger as-child>
-              <UiButton variant="ghost" size="icon">
-                <component :is="menu.icon" />
-              </UiButton>
+              <UiSidebarMenuButton :tooltip="menu.title">
+                <component :is="menu.icon" v-if="menu.icon" />
+                <span>{{ menu.title }}</span>
+              </UiSidebarMenuButton>
             </UiDropdownMenuTrigger>
             <UiDropdownMenuContent align="start" side="right">
               <UiDropdownMenuLabel>{{ menu.title }}</UiDropdownMenuLabel>


### PR DESCRIPTION
## Description

Collapsible sidebar items were bigger than other menu items when sidebar is collapsed, and all of the items were missing tooltips when sidebar collapsed.

## Types of changes

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] If you linted your code?

## Further comments
Before/After
![image](https://github.com/user-attachments/assets/fe4e17bb-f0d1-4618-8ad3-7782d8f41333)

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Closes: #<!-- Issue number, if applicable -->
