### PR TITLE
fix: remove size attribute from UiButton in language-change component…

### DIFF
--- a/src/components/language-change.vue
+++ b/src/components/language-change.vue
@@ -5,7 +5,7 @@ import { Icon } from '@iconify/vue'
 <template>
   <UiDropdownMenu>
     <UiDropdownMenuTrigger as-child>
-      <UiButton variant="outline" size="icon">
+      <UiButton variant="outline">
         <Icon icon="mdi:translate" />
         {{ $t('language') }}
       </UiButton>


### PR DESCRIPTION
remove size attribute from UiButton in language-change component to fix style issues

## Description

<!-- A clear and concise description of what the pull request does. Include any relevant motivation and background. -->

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] If you linted your code?

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Closes: #<!-- Issue number, if applicable -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the language switch button to use the default size (previously “icon”), maintaining the outline variant. This adjusts the button’s dimensions and visual emphasis for a more consistent look with other controls. No functional behavior changed, but spacing and alignment in affected layouts may appear slightly different.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->