### PR TITLE
refactor(auth): replace hardcoded logout text with i18n translation  - Replace static "Log out" text with i18n $t('logout') in nav-footer.vue - Add logout translation entries for en and zh languages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# This is api base url
+# VITE_API_BASE_URL=https://api.example.com
+VITE_SERVER_API_URL=http://localhost:3000
+VITE_SERVER_API_PREFIX=/api
+VITE_SERVER_API_TIMEOUT=5000

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,0 @@
-# This is api base url
-# VITE_API_BASE_URL=https://api.example.com
-VITE_SERVER_API_URL=http://localhost:3000
-VITE_SERVER_API_PREFIX=/api
-VITE_SERVER_API_TIMEOUT=5000

--- a/src/components/app-sidebar/nav-footer.vue
+++ b/src/components/app-sidebar/nav-footer.vue
@@ -99,7 +99,7 @@ const { isMobile, open } = useSidebar()
           <UiDropdownMenuSeparator />
           <UiDropdownMenuItem @click="logout">
             <LogOut />
-            Log out
+            {{ $t('logout') }}
           </UiDropdownMenuItem>
         </UiDropdownMenuContent>
       </UiDropdownMenu>

--- a/src/components/command-menu-panel/index.vue
+++ b/src/components/command-menu-panel/index.vue
@@ -31,7 +31,7 @@ const firstKey = computed(() => navigator?.userAgent.includes('Mac OS') ? '⌘' 
     >
       <div class="flex items-center gap-2">
         <SearchIcon class="size-4" />
-        <span class="text-xs font-semibold text-muted-foreground">Search Menu</span>
+        <span class="text-xs font-semibold text-muted-foreground">{{ $t('homePage.searchKeyWords') }}</span>
       </div>
       <UiKbd>{{ firstKey }} + k</UiKbd>
     </div>

--- a/src/components/language-change.vue
+++ b/src/components/language-change.vue
@@ -1,19 +1,32 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
+import { useStorage } from '@vueuse/core'
+import { useI18n } from 'vue-i18n'
+
+const { locale } = useI18n()
+const storedLocale = useStorage('app-locale', 'en')
+
+function handleLocaleChange(val: string) {
+  locale.value = val
+  storedLocale.value = val
+}
 </script>
 
 <template>
   <UiDropdownMenu>
     <UiDropdownMenuTrigger as-child>
-      <UiButton variant="outline">
-        <Icon icon="mdi:translate" />
+      <UiButton variant="outline" class="w-28 justify-center">
+        <Icon icon="mdi:translate" class="mr-2" />
         {{ $t('language') }}
       </UiButton>
     </UiDropdownMenuTrigger>
-    <UiDropdownMenuContent class="w-56">
+    <UiDropdownMenuContent class="w-28">
       <UiDropdownMenuLabel>{{ $t('changeLanguage') }}</UiDropdownMenuLabel>
       <UiDropdownMenuSeparator />
-      <UiDropdownMenuRadioGroup v-model="$i18n.locale">
+      <UiDropdownMenuRadioGroup
+        v-model="locale"
+        @update:model-value="handleLocaleChange"
+      >
         <UiDropdownMenuRadioItem value="en">
           <Icon icon="flag:us-4x3" />
           <span class="ml-2">English</span>

--- a/src/components/language-change.vue
+++ b/src/components/language-change.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { AcceptableValue } from 'reka-ui'
+
 import { Icon } from '@iconify/vue'
 import { useStorage } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
@@ -6,9 +8,11 @@ import { useI18n } from 'vue-i18n'
 const { locale } = useI18n()
 const storedLocale = useStorage('app-locale', 'en')
 
-function handleLocaleChange(val: string) {
-  locale.value = val
-  storedLocale.value = val
+function handleLocaleChange(val: AcceptableValue) {
+  if (typeof val === 'string') {
+    locale.value = val
+    storedLocale.value = val
+  }
 }
 </script>
 

--- a/src/composables/use-auth.ts
+++ b/src/composables/use-auth.ts
@@ -16,12 +16,12 @@ export function useAuth() {
   }
 
   function toHome() {
-    router.push({ path: '/workspace' })
+    router.push({ path: '/dashboard' })
   }
 
   async function login() {
     loading.value = true
-    await new Promise(resolve => setTimeout(resolve, 1000))
+    await new Promise(resolve => setTimeout(resolve, 10))
     // mock login
     isLogin.value = true
     loading.value = false

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -5,6 +5,7 @@ import { storeToRefs } from 'pinia'
 import AppSidebar from '@/components/app-sidebar/index.vue'
 import CommandMenuPanel from '@/components/command-menu-panel/index.vue'
 import ThemePopover from '@/components/custom-theme/theme-popover.vue'
+import LanguageChange from '@/components/language-change.vue'
 import ToggleTheme from '@/components/toggle-theme.vue'
 import { SIDEBAR_COOKIE_NAME } from '@/components/ui/sidebar/utils'
 import { cn } from '@/lib/utils'
@@ -27,6 +28,7 @@ const { contentLayout } = storeToRefs(themeStore)
         <CommandMenuPanel />
         <div class="flex-1" />
         <div class="ml-auto flex items-center space-x-4">
+          <LanguageChange />
           <ToggleTheme />
           <ThemePopover />
         </div>

--- a/src/pages/auth/components/login-form.vue
+++ b/src/pages/auth/components/login-form.vue
@@ -30,14 +30,14 @@ const { login, loading } = useAuth()
     <UiCardContent class="grid gap-4">
       <div class="grid gap-2">
         <UiLabel for="email">
-          Email
+          {{ $t('loginSubject') }}
         </UiLabel>
         <UiInput id="email" type="email" placeholder="m@example.com" required />
       </div>
       <div class="grid gap-2">
         <div class="flex items-center justify-between">
           <UiLabel for="password">
-            Password
+            {{ $t('loginPwd') }}
           </UiLabel>
           <ToForgotPasswordLink />
         </div>
@@ -46,7 +46,7 @@ const { login, loading } = useAuth()
 
       <UiButton class="w-full" @click="login">
         <UiSpinner v-if="loading" class="mr-2" />
-        Mock Login
+        {{ $t('login') }}
       </UiButton>
 
       <UiSeparator label="Or continue with" />

--- a/src/pages/auth/components/to-forgot-password-link.vue
+++ b/src/pages/auth/components/to-forgot-password-link.vue
@@ -3,6 +3,6 @@
 
 <template>
   <UiButton variant="link" class="text-muted-foreground" @click="$router.push('/auth/forgot-password')">
-    Forgot password?
+    {{ $t('forgotPasswordPage.forgotPassword') }}
   </UiButton>
 </template>

--- a/src/pages/auth/forgot-password.vue
+++ b/src/pages/auth/forgot-password.vue
@@ -18,14 +18,14 @@ import AuthTitle from './components/auth-title.vue'
         <UiCardContent class="grid gap-4">
           <div class="grid gap-2">
             <UiLabel for="email">
-              Email
+              {{ $t('loginSubject') }}
             </UiLabel>
             <UiInput id="email" type="email" placeholder="m@example.com" required />
           </div>
         </UiCardContent>
         <UiCardFooter class="flex flex-col gap-2">
           <UiButton class="w-full">
-            Continue
+            {{ $t('forgotPasswordPage.continue') }}
           </UiButton>
 
           <div>

--- a/src/pages/dashboard/index.vue
+++ b/src/pages/dashboard/index.vue
@@ -24,11 +24,12 @@ const activeTab = ref(tabs.value[0].value)
   >
     <template #actions>
       <Button
+        class="min-w-22"
         @click="() => toast('hello', {
           position: 'top-center',
         })"
       >
-        Download
+        {{ $t('homePage.download') }}
       </Button>
     </template>
 

--- a/src/plugins/i18n/en.json
+++ b/src/plugins/i18n/en.json
@@ -98,8 +98,18 @@
     }
   },
   "login": "Login",
+  "loginSubject": "Email",
+  "loginPwd": "Password",
   "logout": "Log out",
   "register": "Register",
   "language": "English",
+  "forgotPasswordPage": {
+    "continue": "continue",
+    "forgotPassword": "Forgot password?"
+  },
+  "homePage": {
+    "searchKeyWords": "Search Menu",
+    "download": "Download"
+  },
   "changeLanguage": "Change Language"
 }

--- a/src/plugins/i18n/en.json
+++ b/src/plugins/i18n/en.json
@@ -98,6 +98,7 @@
     }
   },
   "login": "Login",
+  "logout": "Log out",
   "register": "Register",
   "language": "English",
   "changeLanguage": "Change Language"

--- a/src/plugins/i18n/setup.ts
+++ b/src/plugins/i18n/setup.ts
@@ -1,14 +1,17 @@
 import type { App } from 'vue'
 
+import { useStorage } from '@vueuse/core'
 import { createI18n } from 'vue-i18n'
 
 import en from './en.json'
 import zh from './zh.json'
 
+const savedLocale = useStorage('app-locale', 'en')
+
 export function setupI18n(app: App) {
   const i18n = createI18n({
     legacy: false,
-    locale: 'en',
+    locale: savedLocale.value,
     fallbackLocale: 'en',
     messages: {
       zh,

--- a/src/plugins/i18n/zh.json
+++ b/src/plugins/i18n/zh.json
@@ -98,6 +98,7 @@
     }
   },
   "login": "登录",
+  "logout": "退出登录",
   "register": "注册",
   "language": "中文",
   "changeLanguage": "语言切换"

--- a/src/plugins/i18n/zh.json
+++ b/src/plugins/i18n/zh.json
@@ -98,8 +98,18 @@
     }
   },
   "login": "登录",
-  "logout": "退出登录",
+  "loginSubject": "邮箱",
+  "loginPwd": "密码",
+  "logout": "退出",
   "register": "注册",
   "language": "中文",
+  "forgotPasswordPage": {
+    "continue": "下一步",
+    "forgotPassword": "忘记密码?"
+  },
+  "homePage": {
+    "searchKeyWords": "搜索菜单",
+    "download": "下载"
+  },
   "changeLanguage": "语言切换"
 }


### PR DESCRIPTION
## Description

- Replaced hardcoded "Log out" text in the sidebar navigation footer with i18n translation to support multilingual display, and added "logout" translation entries in both English and Chinese language files.
- Replaced multiple hardcoded static texts (Search Menu, Email, Password, Mock Login, Forgot password?, Continue, Download) in command-menu-panel, login/forgot-password pages, and dashboard with i18n `$t()` translations to support multilingual display.
- Optimized language-change component to persist user's language preference in localStorage, keeping selected language after refresh or reopen.
- Added corresponding translation entries in en.json and zh.json (loginSubject, loginPwd, forgotPasswordPage, homePage), and adjusted logout Chinese translation for better consistency.
- Updated i18n setup logic to load locale from localStorage instead of hardcoded value.
- Integrated LanguageChange component into default layout and removed unused .env.example file.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [x] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->
- [x] I linted my code

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
- Hardcoded text affects multilingual experience and consistency. Using `$t('logout')` and other i18n keys keeps the same logic as other i18n texts in the project.
- Translation keys and files follow existing structure and naming conventions for better maintainability.
- Persisting locale in localStorage improves user experience for multilingual users, avoiding language reset after page refresh.

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->
Closes: #<!-- Issue number, if applicable -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login now redirects to the dashboard and has a much shorter simulated delay.

* **Localization**
  * Added English/Chinese translations for login, logout, forgot-password and home UI strings.
  * Multiple UI labels updated to use translations (login, password, search, download, forgot password, logout).

* **New Features**
  * Persistent language selector added to the header (locale saved in storage).

* **Chores**
  * Removed example environment file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->