### PR TITLE
refactor: The language button size has been changed to 36x36 and unnecessary content has been removed to accommodate size changes when switching languages

### DIFF
--- a/src/components/language-change.vue
+++ b/src/components/language-change.vue
@@ -29,25 +29,22 @@ function handleLocaleChange(val: AcceptableValue) {
 <template>
   <UiDropdownMenu>
     <UiDropdownMenuTrigger as-child>
-      <UiButton variant="outline">
-        <Icon icon="mdi:translate" class="mr-2" />
-        {{ $t('language') }}
+      <UiButton variant="outline" size="icon">
+        <Icon icon="mdi:translate" />
       </UiButton>
     </UiDropdownMenuTrigger>
     <UiDropdownMenuContent>
-      <UiDropdownMenuLabel>{{ $t('changeLanguage') }}</UiDropdownMenuLabel>
-      <UiDropdownMenuSeparator />
       <UiDropdownMenuRadioGroup
         v-model="locale"
         @update:model-value="handleLocaleChange"
       >
         <UiDropdownMenuRadioItem value="en">
           <Icon icon="flag:us-4x3" />
-          <span class="ml-2">English</span>
+          <span>English</span>
         </UiDropdownMenuRadioItem>
         <UiDropdownMenuRadioItem value="zh">
           <Icon icon="flag:cn-4x3" />
-          <span class="ml-2">中文</span>
+          <span>中文</span>
         </UiDropdownMenuRadioItem>
       </UiDropdownMenuRadioGroup>
     </UiDropdownMenuContent>

--- a/src/components/language-change.vue
+++ b/src/components/language-change.vue
@@ -29,8 +29,14 @@ function handleLocaleChange(val: AcceptableValue) {
 <template>
   <UiDropdownMenu>
     <UiDropdownMenuTrigger as-child>
-      <UiButton variant="outline" size="icon">
+      <UiButton
+        variant="outline"
+        size="icon"
+        aria-label="Change language"
+        title="Change language"
+      >
         <Icon icon="mdi:translate" />
+        <span class="sr-only">Change language</span>
       </UiButton>
     </UiDropdownMenuTrigger>
     <UiDropdownMenuContent>

--- a/src/plugins/i18n/en.json
+++ b/src/plugins/i18n/en.json
@@ -104,12 +104,10 @@
   "logout": "Log out",
   "forgotPassword": "Forgot password?",
   "register": "Register",
-  "language": "English",
   "forgotPasswordPage": {
     "continue": "continue"
   },
   "homePage": {
     "searchKeyWords": "Search Menu"
-  },
-  "changeLanguage": "Change Language"
+  }
 }

--- a/src/plugins/i18n/zh.json
+++ b/src/plugins/i18n/zh.json
@@ -104,12 +104,10 @@
   "logout": "退出",
   "forgotPassword": "忘记密码?",
   "register": "注册",
-  "language": "中文",
   "forgotPasswordPage": {
     "continue": "下一步"
   },
   "homePage": {
     "searchKeyWords": "搜索菜单"
-  },
-  "changeLanguage": "语言切换"
+  }
 }


### PR DESCRIPTION
## Description
优化语言切换按钮组件：
- 将语言按钮尺寸统一调整为 36×36，与主题切换按钮保持视觉一致
- 删除切换语言时非必要的 DOM 结构与样式，解决按钮宽度跳动问题
- 移除组件内多余的国际化文本，简化代码结构

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in the boxes that apply -->
- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Others (any other types not listed above)

## Checklist
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x] -->
- [x] I have linted my code

## Further comments
本次修改仅为 UI 样式与代码结构优化，无业务逻辑改动，不影响原有功能。
- 统一了头部导航栏图标按钮尺寸，提升界面一致性
- 修复了切换语言时按钮宽度变化的视觉问题
- 精简了组件代码，减少不必要的 DOM 渲染

## Related Issue
<!-- If this PR is related to an existing issue, link to it here. -->
Closes: #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Language selector is now an icon-only outline button for a more compact header.
  * Dropdown header simplified and language options aligned tighter beside flags for a cleaner look.

* **Accessibility**
  * Icon button includes accessible labels and hidden screen-reader text for improved navigation.

* **Chores**
  * Removed obsolete translation entries from language packs to keep wording consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->