### PR TITLE
fix: prevent sidebar scroll reset on route change

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,7 +11,7 @@ useSystemTheme()
 
   <Suspense>
     <router-view v-slot="{ Component, route }">
-      <component :is="Component" :key="route" />
+      <component :is="Component" />
     </router-view>
 
     <template #fallback>

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,7 @@ useSystemTheme()
   <Toaster />
 
   <Suspense>
-    <router-view v-slot="{ Component, route }">
+    <router-view v-slot="{ Component }">
       <component :is="Component" />
     </router-view>
 

--- a/src/components/app-sidebar/nav-team-collapsible.vue
+++ b/src/components/app-sidebar/nav-team-collapsible.vue
@@ -18,7 +18,8 @@ const initialPath = route.path
 const { state, isMobile } = useSidebar()
 
 function isCollapsed(menu: NavItem): boolean {
-  if (menu.url === initialPath) return true
+  if (menu.url === initialPath)
+    return true
   return !!menu.items?.some(item => item.url === initialPath)
 }
 

--- a/src/components/app-sidebar/nav-team-collapsible.vue
+++ b/src/components/app-sidebar/nav-team-collapsible.vue
@@ -13,19 +13,13 @@ const { navMain } = defineProps<{
 }>()
 
 const route = useRoute()
+const initialPath = route.path
 
 const { state, isMobile } = useSidebar()
 
 function isCollapsed(menu: NavItem): boolean {
-  const pathname = route.path
-  navMain.forEach((group) => {
-    group.items.forEach((item) => {
-      if (item.url === pathname) {
-        return true
-      }
-    })
-  })
-  return !!menu.items?.some(item => item.url === pathname)
+  if (menu.url === initialPath) return true
+  return !!menu.items?.some(item => item.url === initialPath)
 }
 
 function isActive(menu: NavItem): boolean {


### PR DESCRIPTION
## Summary

- Remove `:key="route"` from the root `<router-view>` in `App.vue`. The key binding caused the entire default layout (sidebar + header + main) to be destroyed and recreated on every navigation, resetting the sidebar scroll position. Without the key, Vue reuses the same layout instance and only swaps the inner page content.
- Refactor `isCollapsed()` in `nav-team-collapsible.vue` to snapshot the initial route path instead of using the reactive `route.path`, preventing collapsible open state from jumping on subsequent navigations.

## Before

Clicking any sidebar link destroys and recreates the entire layout (including the sidebar), causing the scroll position to reset to the top.

## After

Vue reuses the same layout component instance across route changes. Only the inner `<router-view />` content is swapped. Sidebar scroll position is preserved.

## Test plan

- [ ] Navigate to a page that requires scrolling the sidebar (e.g., many nav items)
- [ ] Scroll the sidebar to a non-top position
- [ ] Click a different sidebar item
- [ ] Verify the sidebar scroll position is preserved
- [ ] Verify the collapsible nav groups maintain their open/close state correctly
- [ ] Verify active item highlighting still works after navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar collapse now opens the correct section by default based on the current page, including nested items.
  * Routed views no longer force remounts on route changes, preserving component state and improving navigation responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Whbbit1999/shadcn-vue-admin/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->